### PR TITLE
IJD-383 | google auth, generate username if not present

### DIFF
--- a/starter.sql
+++ b/starter.sql
@@ -186,9 +186,31 @@ alter table user_meta
 create or replace function public.handle_new_auth_user()
     returns trigger as
 $$
+declare
+    generated_username text;
+    base_username text;
+    user_count int;
 begin
+    -- If username is provided, use it; otherwise (In OAuth case), generate from full_name
+    if (new.raw_user_meta_data ->> 'username') is null or (new.raw_user_meta_data ->> 'username') = '' then
+        -- Generate base username from full_name (remove special characters and convert to lowercase)
+        base_username := lower(trim(regexp_replace(new.raw_user_meta_data ->> 'full_name', '[^a-zA-Z0-9]', '', 'g')));
+
+        -- Count existing usernames with the same base name
+        select count(*) into user_count from public.profiles where username like base_username || '%';
+
+        -- If username already exists, append the count + 1
+        if user_count > 0 then
+            generated_username := base_username || (user_count + 1);
+        else
+            generated_username := base_username;
+        end if;
+    else
+        generated_username := new.raw_user_meta_data ->> 'username';
+    end if;
+
     insert into public.profiles (id, full_name, username, avatar_url)
-    values (new.id, new.raw_user_meta_data ->> 'full_name', new.raw_user_meta_data ->> 'username',new.raw_user_meta_data ->> 'avatar_url');
+    values (new.id, new.raw_user_meta_data ->> 'full_name', generated_username, new.raw_user_meta_data ->> 'avatar_url');
 
     insert into public.user_meta (id)
     values (new.id);


### PR DESCRIPTION
These pr changes, will generate username as new auth triggers. In case of  username is null

Input :
![image](https://github.com/user-attachments/assets/a8aea689-01ad-4bd8-8cee-d3d8c2098b15)

output: 
![image](https://github.com/user-attachments/assets/0bedc00c-561b-40bc-bf43-1c49f0b01239)



<details>

<summary>Used this environment to test it</summary>

```
CREATE TABLE IF NOT EXISTS test_env.profiles (
    id uuid primary key,
    full_name text not null,
    username text unique not null,
    avatar_url text
);

CREATE TABLE IF NOT EXISTS test_env.auth_users (
    id uuid primary key default gen_random_uuid(),
    raw_user_meta_data jsonb not null
);

CREATE TABLE IF NOT EXISTS test_env.user_meta (
    id uuid primary key
);

create or replace function test_env.handle_new_auth_user()
    returns trigger as
$$
declare
    generated_username text;
    base_username text;
    user_count int;
begin
    if (new.raw_user_meta_data ->> 'username') is null or (new.raw_user_meta_data ->> 'username') = '' then
        base_username := lower(trim(regexp_replace(new.raw_user_meta_data ->> 'full_name', '[^a-zA-Z0-9]', '', 'g')));
        select count(*) into user_count from test_env.profiles where username like base_username || '%';
        generated_username := case when user_count > 0 then base_username || (user_count + 1) else base_username end;
    else
        generated_username := new.raw_user_meta_data ->> 'username';
    end if;

    insert into test_env.profiles (id, full_name, username, avatar_url)
    values (new.id, new.raw_user_meta_data ->> 'full_name', generated_username, new.raw_user_meta_data ->> 'avatar_url');

    insert into test_env.user_meta (id) values (new.id);

    return new;
end;
$$
language plpgsql;

create table test_env.auth_users (
    id uuid primary key default gen_random_uuid(),
    raw_user_meta_data jsonb not null
);

create trigger new_auth_user_trigger
    after insert on test_env.auth_users
    for each row execute function test_env.handle_new_auth_user();


```

</details>

