### PR TITLE
IJD-468 | update newletter consent in user_meta  table's user_notification column

### DIFF
--- a/starter.sql
+++ b/starter.sql
@@ -197,6 +197,12 @@ begin
     insert into public.user_meta (id)
     values (new.id);
 
+    if new.raw_user_meta_data ->> 'newsletter' is not null then
+        update public.user_meta
+        set user_notification = jsonb_set(user_notification, '{newsletter}', to_jsonb((new.raw_user_meta_data ->> 'newsletter')::boolean))
+        where id = new.id;
+    end if;
+
     return new;
 end;
 $$ language plpgsql security definer;


### PR DESCRIPTION
Please check/test these changes or let me know how it can be done.
This PR will update new user consent of newsletter into user_meta table in column user_notification (json)
